### PR TITLE
优化本地m3u8服务与bug修复

### DIFF
--- a/.github/workflows/package_exe.yml
+++ b/.github/workflows/package_exe.yml
@@ -35,4 +35,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: y2qq_GUI
-          path: release
+          path: .

--- a/.github/workflows/package_exe.yml
+++ b/.github/workflows/package_exe.yml
@@ -18,21 +18,22 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      - name: Test Build Python Exe
+      - name: Build Python Exe
         uses: eric2788/pyinstaller-build@master
         with:
           main: y2qq_GUI
           use-dependencies: true
+          artifact: y2qq_GUI
           
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: y2qq_GUI
-          path: .
+          path: dist

--- a/.github/workflows/package_exe.yml
+++ b/.github/workflows/package_exe.yml
@@ -35,4 +35,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: y2qq_GUI
-          path: dist
+          path: release

--- a/.github/workflows/package_exe.yml
+++ b/.github/workflows/package_exe.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: package_exe
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Test Build Python Exe
+        uses: eric2788/pyinstaller-build@master
+        with:
+          main: y2qq_GUI
+          use-dependencies: true
+          
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: y2qq_GUI
+          path: dist

--- a/.github/workflows/package_exe.yml
+++ b/.github/workflows/package_exe.yml
@@ -31,6 +31,7 @@ jobs:
           main: y2qq_GUI
           use-dependencies: true
           artifact: y2qq_GUI
+          no-console: true
           
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -5,14 +5,40 @@ windows端可直接运行编译好的y2qq.exe。
 其他平台下载本项目，用python运行y2qq_GUI.py即可。
 
 #### 依赖：
-
-ffmpeg https://ffmpeg.org/download.html  
-youtube-dl https://yt-dl.org/downloads/2021.12.17/youtube-dl.exe  
-注：若直接运行python文件，需安装PySimpleGUI库  
+## ffmpeg
+https://ffmpeg.org/download.html  
+## 依赖包
 ```
-pip install PySimpleGUI
+pip install -r .\requirements.txt
 ```
 
+#### exe打包流程
+   
+1. 安装虚拟环境
+```
+pip install virtualenv
+```
+
+2. 创建虚拟环境
+```
+virtualenv win_pack
+```
+
+3. powershell运行权限设置 (如有)
+```
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
+```
+
+4. 打开虚拟环境 (如使用IDE可直接选择环境)
+```
+./win_pack/Scripts/Activate.ps1
+```
+
+5. 运行打包
+```
+pip install -r .\requirements.txt
+pyinstaller -wF --clean .\y2qq_GUI.py
+```
 
 
  

--- a/m3u8_cache/server.py
+++ b/m3u8_cache/server.py
@@ -9,13 +9,17 @@ class LocalM3u8_Handler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         fn = self.path.split("/")[1]
         if fn.endswith(".m3u8"):  # for better understanding url
-            fn = fn.split(".m3u8")[0]
-            if m3u8_cache.g_m3u8_cache.get(fn) and m3u8_cache.request_remote_m3u8(fn):
+            video_id = fn.split(".m3u8")[0]
+
+            # update m3u8 for next request
+            m3u8_cache.request_remote_m3u8_async(video_id)
+
+            if m3u8_cache.g_m3u8_cache.get(video_id):
                 self.send_response(200)
                 self.send_header("Content-type", "text/plain; charset=UTF-8")
                 self.end_headers()
 
-                data = m3u8_cache.g_m3u8_cache[fn]
+                data = m3u8_cache.g_m3u8_cache[video_id]
                 self.wfile.write(data.encode("utf-8"))
                 return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pyinstaller
+PySimpleGUI
+requests
+youtube_dl
+beautifulsoup4
+PyYAML


### PR DESCRIPTION
在裁剪时去掉头部的 #EXT-X-DISCONTINUITY，优化点点性能
添加异步请求远端m3u8，并在初始化时用同步方法获取远端m3u8，这样可以优化由ffmpeg请求本地m3u8的卡顿问题，减少断连

另外由于使用了本地m3u8的原因，ffmpeg在转发时会一直重试直到 远端不再接收，这样就不用一直重试推送