### PR TITLE
修复错误

### DIFF
--- a/y2qq.py
+++ b/y2qq.py
@@ -43,11 +43,13 @@ def get_format(in_url):
 
 def restream(m3u8, in_ffmpeg, in_key):
     global g_process
+    stop_restream()
+    
     ffmpeg_path = in_ffmpeg
     key = in_key
     try:
         g_process = sp.Popen(
-            [ffmpeg_path, '-i', m3u8, '-vcodec', 'copy', '-acodec', 'aac', '-f', 'flv', f"rtmp://6721.livepush.myqcloud.com/live/{key}"], stdout=sp.PIPE, stderr=sp.STDOUT, universal_newlines=True)
+            [ffmpeg_path, "-re", '-i', m3u8, '-vcodec', 'copy', '-acodec', 'aac', '-f', 'flv', f"rtmp://6721.livepush.myqcloud.com/live/{key}"], stdout=sp.PIPE, stderr=sp.STDOUT, universal_newlines=True)
         for line in g_process.stdout:
             if 'speed' in line:
                 sg.cprint(line.rstrip("\n"))

--- a/y2qq_GUI.py
+++ b/y2qq_GUI.py
@@ -243,6 +243,7 @@ try:
             pass
         elif event == "停止推流":
             y2qq.stop_restream()
+            m3u8_cache.stop_server_produce_m3u8()
             sg.cprint("推流已经停止")
         elif event == "save_yaml":
             btn_save_config_yaml(values)


### PR DESCRIPTION
修复错误地去掉#EXT-X-DISCONTINUITY时，更改了 SEQUENCE 的数目导致流混乱的问题
更改远端m3u8更新方式为另外线程查询，这是因为当ffmpeg有足够的ts未推送时会降低查询m3u8列表，导致没有及时更新远端m3u8而出现更多的#EXT-X-DISCONTINUITY。
当#EXT-X-DISCONTINUITY出现时画面会停顿，这个是按照hls的规则只能是这样的